### PR TITLE
Add check for version coverage

### DIFF
--- a/src/Tests/CheckForUntestedVersions.cs
+++ b/src/Tests/CheckForUntestedVersions.cs
@@ -1,0 +1,66 @@
+﻿namespace Tests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NuGet.Common;
+    using NuGet.Protocol;
+    using NuGet.Protocol.Core.Types;
+    using NuGet.Versioning;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class CheckForUntestedVersions
+    {
+        [Test]
+        public async Task Should_test_latest_minor_versions()
+        {
+            var versions = await GetAllNServiceBusVersions();
+
+            var latestVersions = versions
+                .GroupBy(v => v.Version.Major)
+                .Select(group => group
+                    .Where(v => !v.IsPrerelease)
+                    .Max());
+
+            foreach (var latestVersion in latestVersions)
+            {
+                var name = $"NServiceBus{latestVersion.Major}.{latestVersion.Minor}";
+                if (!Directory.Exists(Path.Combine(projectDirectory, name)))
+                {
+                    Assert.Fail($"No test project for {name} found.");
+                }
+            }
+        }
+
+        [Test]
+        public async Task Should_test_latest_unstable()
+        {
+            var versions = await GetAllNServiceBusVersions();
+
+            var latestPrerelease = versions.Where(v => v.IsPrerelease).Max();
+
+            var name = $"NServiceBus{latestPrerelease.Major}.{latestPrerelease.Minor}";
+            if (!Directory.Exists(Path.Combine(projectDirectory, name)))
+            {
+                Assert.Fail($"No test project for {name} found.");
+            }
+        }
+
+        private static async Task<NuGetVersion[]> GetAllNServiceBusVersions()
+        {
+            var repository = Repository.Factory.GetCoreV3("https://www.myget.org/F/particular/api/v3/index.json");
+            var result = await repository.GetResourceAsync<FindPackageByIdResource>()
+                .ConfigureAwait(false);
+            var versions = (await result.GetAllVersionsAsync("NServiceBus", Cache, NullLogger.Instance, CancellationToken.None)
+                    .ConfigureAwait(false))
+                .ToArray();
+            return versions;
+        }
+
+        private readonly string projectDirectory = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\..\..\"));
+        private static readonly SourceCacheContext Cache = new SourceCacheContext();
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -8,6 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CliWrap" Version="3.3.1" />
+		<PackageReference Include="NuGet.Protocol" Version="5.9.0" />
 		<PackageReference Include="NUnit" Version="3.13.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
adds two test cases that when run will check the following two conditions:
* Ensures that a test project for the latest minor version of every available major version is there. e.g. NServiceBus 5.2, 6.5, 7.4 and so on.
  * This does explicitly not test for older minor versions as this might be something that we want to drop at some point but this ensures that new minor releases on supported versions will be added to the test project.
* Ensures that a major version project will be added as soon as there is an unstable version of this version on our myget feed (currently, this expected a 8.0 test project to be created).
  * This helps to make sure that we're catching any potential issues early in the development process of new major versions

Note: These tests are currently failing due to the missing projects for v7/v8