### PR TITLE
Fix v6 serializer usage

### DIFF
--- a/src/NServiceBus6.0/JsonSerializerFacade.cs
+++ b/src/NServiceBus6.0/JsonSerializerFacade.cs
@@ -22,10 +22,7 @@ class JsonSerializerFacade : ISerializerFacade
 
     public void Serialize(Stream stream, object instance)
     {
-        serializer.Serialize(new[]
-        {
-            instance
-        }, stream);
+        serializer.Serialize(instance, stream);
     }
 
     public object[] Deserialize(Stream stream)


### PR DESCRIPTION
V6 should not wrap the message in an array like v4 does (v5 also does not wrap). See v6 usage of the serializer here: https://github.com/Particular/NServiceBus/blob/6.5.10/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs#L46