### PR TITLE
Remove tuple

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -7,7 +7,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="NUnit" Version="3.13.1" />
-		<PackageReference Include="System.ValueTuple" Version="4.5.0" />		
 	</ItemGroup>	
 
 </Project>

--- a/src/Common/PackageVersion.cs
+++ b/src/Common/PackageVersion.cs
@@ -1,0 +1,16 @@
+﻿namespace Common
+{
+    public readonly struct PackageVersion
+    {
+        public PackageVersion(int major, int minor, int patch)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+        }
+
+        public int Major { get; }
+        public int Minor { get; }
+        public int Patch { get; }
+    }
+}

--- a/src/Common/Program.cs
+++ b/src/Common/Program.cs
@@ -38,7 +38,7 @@ class Program
                     foreach (var testCase in testCases)
                     {
                         var serializer = (ISerializerFacade)Activator.CreateInstance(serializerType, testCase.MessageType);
-                        if (testCase.IsSupported(serializer.SerializationFormat, new ValueTuple<int, int, int>(NsbVersion.FileMajorPart, NsbVersion.FileMinorPart, NsbVersion.FileBuildPart)))
+                        if (testCase.IsSupported(serializer.SerializationFormat, new PackageVersion(NsbVersion.FileMajorPart, NsbVersion.FileMinorPart, NsbVersion.FileBuildPart)))
                         {
                             Console.WriteLine($"{serializer.SerializationFormat:G} — {testCase.GetType().Name}");
                             Serialize(serializer, testCase);
@@ -60,7 +60,7 @@ class Program
                             var serializer =
                                 (ISerializerFacade)Activator.CreateInstance(serializerType, testCase.MessageType);
                             if (testCase.IsSupported(serializer.SerializationFormat,
-                                new ValueTuple<int, int, int>(NsbVersion.FileMajorPart, NsbVersion.FileMinorPart,
+                                new PackageVersion(NsbVersion.FileMajorPart, NsbVersion.FileMinorPart,
                                     NsbVersion.FileBuildPart)))
                             {
                                 Console.WriteLine($"{serializer.SerializationFormat:G} — {testCase.GetType().Name}");

--- a/src/Common/Tests/TestCase.cs
+++ b/src/Common/Tests/TestCase.cs
@@ -6,7 +6,7 @@
     {
         public abstract Type MessageType { get; }
 
-        public virtual bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version) => true;
+        public virtual bool IsSupported(SerializationFormat format, PackageVersion version) => true;
 
         public abstract void Populate(object instance);
 

--- a/src/Common/Tests/TestCases/Failing.cs
+++ b/src/Common/Tests/TestCases/Failing.cs
@@ -10,7 +10,7 @@
 
         //HINT: we need to put it and Passing here as Test.dll is not loaded into each custom nsb appdomains
         //      only Common.dll is. It should never run with other serialization test cases.
-        public override bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version) => false;
+        public override bool IsSupported(SerializationFormat format, PackageVersion version) => false;
 
         public override void Populate(object instance)
         {

--- a/src/Common/Tests/TestCases/Passing.cs
+++ b/src/Common/Tests/TestCases/Passing.cs
@@ -9,7 +9,7 @@
 
         //HINT: we need to put it and Passing here as Test.dll is not loaded into each custom nsb appdomains
         //      only Common.dll is. It should never run with other serialization test cases.
-        public override bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version) => false;
+        public override bool IsSupported(SerializationFormat format, PackageVersion version) => false;
 
         public override void Populate(object instance)
         {

--- a/src/Common/Tests/TestCases/TestDates.cs
+++ b/src/Common/Tests/TestCases/TestDates.cs
@@ -6,7 +6,7 @@
 
     public class TestDates : TestCase
     {
-        public override bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version)
+        public override bool IsSupported(SerializationFormat format, PackageVersion version)
         {
             if (format != SerializationFormat.Json)
             {

--- a/src/Common/Tests/TestCases/TestDictionaries.cs
+++ b/src/Common/Tests/TestCases/TestDictionaries.cs
@@ -10,7 +10,7 @@
     {
         public override Type MessageType => typeof(MessageWithDictionaries);
 
-        public override bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version)
+        public override bool IsSupported(SerializationFormat format, PackageVersion version)
         {
             return version.Major > 3 || (version.Major == 3 && version.Minor == 3);
         }

--- a/src/Common/Tests/TestCases/TestGenericMessage.cs
+++ b/src/Common/Tests/TestCases/TestGenericMessage.cs
@@ -8,7 +8,7 @@
     {
         public override Type MessageType => typeof(GenericMessage<int, string>);
 
-        public override bool IsSupported(SerializationFormat format, ValueTuple<int, int, int> version)
+        public override bool IsSupported(SerializationFormat format, PackageVersion version)
         {
             if (format == SerializationFormat.Xml)
             {

--- a/src/Common/Tests/TestCases/TestInvalidCharacter.cs
+++ b/src/Common/Tests/TestCases/TestInvalidCharacter.cs
@@ -9,7 +9,7 @@
     {
         public override Type MessageType => typeof(MessageWithInvalidCharacter);
 
-        public override bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version)
+        public override bool IsSupported(SerializationFormat format, PackageVersion version)
         {
             return version.Major != 3;
         }

--- a/src/Common/Tests/TestCases/TestPolymorphicCollections.cs
+++ b/src/Common/Tests/TestCases/TestPolymorphicCollections.cs
@@ -9,7 +9,7 @@
     {
         public override Type MessageType => typeof(PolymorphicCollection);
 
-        public override bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version)
+        public override bool IsSupported(SerializationFormat format, PackageVersion version)
         {
             return format == SerializationFormat.Json;
         }

--- a/src/Common/Tests/TestCases/TestXmlSpecialCharacters.cs
+++ b/src/Common/Tests/TestCases/TestXmlSpecialCharacters.cs
@@ -8,7 +8,7 @@
     {
         public override Type MessageType => typeof(TestMessageWithChar);
 
-        public override bool IsSupported(SerializationFormat format, (int Major, int Minor, int Patch) version)
+        public override bool IsSupported(SerializationFormat format, PackageVersion version)
         {
             return version.Major != 3;
         }

--- a/src/NServiceBus6.0/NServiceBus6.0.csproj
+++ b/src/NServiceBus6.0/NServiceBus6.0.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="NServiceBus" Version="6.0.3" />		
+		<PackageReference Include="NServiceBus" Version="6.0.*" />		
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Small refactoring to stop using `ValueTuple` (because it continues to complain when looking at some files because of missing specified language version).

Also adds a missing wildcard version specifier for the v6.0 project.