### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10

--- a/.reposync.yml
+++ b/.reposync.yml
@@ -1,0 +1,2 @@
+exclusions:
+- .github/dependabot.yml


### PR DESCRIPTION
We don't want dependabot to try to upgrade all the version specific projects. They are intentionally on older versions.