### PR TITLE
Add exclude functionality

### DIFF
--- a/src/Common/Excludes.cs
+++ b/src/Common/Excludes.cs
@@ -1,0 +1,43 @@
+﻿namespace Common
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Tests;
+
+    /// <summary>
+    /// Allows a specific test project to define test files that should not be verified.
+    /// Create a class called "ExcludeList" without a namespace in the project and provide the file names per test case that should be ignored.
+    /// </summary>
+    public abstract class Excludes
+    {
+        protected abstract Dictionary<Type, string[]> FilesToExclude { get; }
+
+        public static Excludes BuildExcludes()
+        {
+            var excludeListType = Type.GetType("ExcludeList," + Assembly.GetEntryAssembly().FullName, false);
+            if (excludeListType != null)
+            {
+                return (Excludes)Activator.CreateInstance(excludeListType);
+            }
+
+            return new EmptyExcludes();
+        }
+
+        public bool Contains(TestCase testCase, string fileName)
+        {
+            if (FilesToExclude.TryGetValue(testCase.GetType(), out var filesToExclude))
+            {
+                return filesToExclude.Contains(fileName);
+            }
+
+            return false;
+        }
+    }
+
+    class EmptyExcludes : Excludes
+    {
+        protected override Dictionary<Type, string[]> FilesToExclude { get; } = new Dictionary<Type, string[]>(0);
+    }
+}


### PR DESCRIPTION
This is intended as a small workaround to prevent test cases from failing for certain test combinations that are known to fail but might not be fixed quickly. This code is intended to be easily removable once the expected behavior has been defined more explicitly.

A test project can exclude certain deserialization test cases by implementing the `Excludes` class in the project, e.g.:

```
public class ExcludeList : Excludes
{
    protected override Dictionary<Type, string[]> FilesToExclude { get; } = new Dictionary<Type, string[]>
    {
        {typeof(TestEvents), new[] {"NServiceBus3.3 .NET Framework 4.5.2.json"}}
    };
}
```

This class can define any set of files that should be excluded on a specific test case per test project.

Note: The class must be exactly named this way to allow discovery from `Program.cs`. The class must not be in a namespace.

Not particularly happy with the naming, definitely open for suggestions.

