### PR TITLE
Run tests against .NET Core

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net452</TargetFramework>
+		<TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 

--- a/src/Common/Tests/TestCase.cs
+++ b/src/Common/Tests/TestCase.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public abstract class TestCase : MarshalByRefObject
+    public abstract class TestCase
     {
         public abstract Type MessageType { get; }
 

--- a/src/NServiceBus7.0/NServiceBus7.0.csproj
+++ b/src/NServiceBus7.0/NServiceBus7.0.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus7.1/NServiceBus7.1.csproj
+++ b/src/NServiceBus7.1/NServiceBus7.1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus7.2/NServiceBus7.2.csproj
+++ b/src/NServiceBus7.2/NServiceBus7.2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus7.3/NServiceBus7.3.csproj
+++ b/src/NServiceBus7.3/NServiceBus7.3.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus7.4/NServiceBus7.4.csproj
+++ b/src/NServiceBus7.4/NServiceBus7.4.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus8.0/NServiceBus8.0.csproj
+++ b/src/NServiceBus8.0/NServiceBus8.0.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/SerializationTests.cs
+++ b/src/Tests/SerializationTests.cs
@@ -24,22 +24,10 @@
             var errorOutput = new StringBuilder();
             try
             {
-                if (testDescription.Platform.StartsWith("netcoreapp"))
-                {
-                    await Cli.Wrap("dotnet")
-                        .WithArguments("run -- Serialize")
-                        .WithWorkingDirectory(Path.Combine(testDescription.Directory, "..\\..\\.."))
-                        .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput))
-                        .WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput))
-                        .ExecuteAsync();
-                }
-                else
-                {
-                    var execPath = Path.Combine(testDescription.Directory, testDescription.Name + ".exe");
-                    await Cli.Wrap(execPath)
-                        .WithArguments("Serialize")
-                        .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput)).WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput)).ExecuteAsync();
-                }
+                var execPath = Path.Combine(testDescription.Directory, testDescription.Name + ".exe");
+                await Cli.Wrap(execPath)
+                    .WithArguments("Serialize")
+                    .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput)).WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput)).ExecuteAsync();
             }
             catch (Exception e)
             {

--- a/src/Tests/SerializationTests.cs
+++ b/src/Tests/SerializationTests.cs
@@ -20,14 +20,16 @@
         [TestCaseSource(typeof(TestCaseGenerator), nameof(TestCaseGenerator.NServiceBusVersions))]
         public async Task Serialize(TestDescription testDescription)
         {
+            var execPath = Path.Combine(testDescription.Directory, testDescription.Name + ".exe");
             var standardOutput = new StringBuilder();
             var errorOutput = new StringBuilder();
             try
             {
-                var execPath = Path.Combine(testDescription.Directory, testDescription.Name + ".exe");
                 await Cli.Wrap(execPath)
                     .WithArguments("Serialize")
-                    .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput)).WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput)).ExecuteAsync();
+                    .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput))
+                    .WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput))
+                    .ExecuteAsync();
             }
             catch (Exception e)
             {

--- a/src/Tests/SerializationTests.cs
+++ b/src/Tests/SerializationTests.cs
@@ -20,12 +20,26 @@
         [TestCaseSource(typeof(TestCaseGenerator), nameof(TestCaseGenerator.NServiceBusVersions))]
         public async Task Serialize(TestDescription testDescription)
         {
-            var execPath = Path.Combine(testDescription.Directory, testDescription.Name + ".exe");
             var standardOutput = new StringBuilder();
             var errorOutput = new StringBuilder();
             try
             {
-                await Cli.Wrap(execPath).WithArguments("Serialize").WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput)).WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput)).ExecuteAsync();
+                if (testDescription.Platform.StartsWith("netcoreapp"))
+                {
+                    await Cli.Wrap("dotnet")
+                        .WithArguments("run -- Serialize")
+                        .WithWorkingDirectory(Path.Combine(testDescription.Directory, "..\\..\\.."))
+                        .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput))
+                        .WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput))
+                        .ExecuteAsync();
+                }
+                else
+                {
+                    var execPath = Path.Combine(testDescription.Directory, testDescription.Name + ".exe");
+                    await Cli.Wrap(execPath)
+                        .WithArguments("Serialize")
+                        .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutput)).WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOutput)).ExecuteAsync();
+                }
             }
             catch (Exception e)
             {

--- a/src/Tests/TestCaseGenerator.cs
+++ b/src/Tests/TestCaseGenerator.cs
@@ -27,8 +27,8 @@
                 {
                     var versionName = match.Groups[0];
 
-                    var platforms = Directory.GetDirectories(Path.Combine(directory, "bin", ConfigurationFolder))
-                        .Where(p => !p.Contains("netcoreapp")); // currently not supported
+                    var platforms = Directory.GetDirectories(Path.Combine(directory, "bin", ConfigurationFolder));
+                    //.Where(p => !p.Contains("netcoreapp")); // currently not supported
 
                     foreach (var platformPath in platforms)
                     {

--- a/src/Tests/TestCaseGenerator.cs
+++ b/src/Tests/TestCaseGenerator.cs
@@ -28,7 +28,6 @@
                     var versionName = match.Groups[0];
 
                     var platforms = Directory.GetDirectories(Path.Combine(directory, "bin", ConfigurationFolder));
-                    //.Where(p => !p.Contains("netcoreapp")); // currently not supported
 
                     foreach (var platformPath in platforms)
                     {


### PR DESCRIPTION
Change the test infra to run the projects against .NET Core too if a build target is available.

Note: This requires the project to target at least .NET Core 3 as this seems to be the version at which executables are produced in the bin folder so there is no need to execute the project using `dotnet run` or to publish the project first.