### PR TITLE
adding missing constructor argument

### DIFF
--- a/src/NServiceBus8.0/XmlSerializerFacade.cs
+++ b/src/NServiceBus8.0/XmlSerializerFacade.cs
@@ -20,7 +20,7 @@ class XmlSerializerFacade : ISerializerFacade
         settings.Set((MessageMetadataRegistry)Activator.CreateInstance
             (typeof(MessageMetadataRegistry),
             BindingFlags.NonPublic | BindingFlags.Instance, null,
-            new object[] { new Func<Type, bool>(conventions.IsMessageType) },
+            new object[] { new Func<Type, bool>(conventions.IsMessageType), true },
             null));
         settings.Set(conventions);
 


### PR DESCRIPTION
V8-alpha.3024 introduced a constructor argument change to `MessageMetadataRegistry` which instantiated using reflection.  These changes add the missing constructor argument.