### PR TITLE
Use wildcard for v8.0 patch versions

### DIFF
--- a/src/NServiceBus8.0/NServiceBus8.0.csproj
+++ b/src/NServiceBus8.0/NServiceBus8.0.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.1" />
+    <PackageReference Include="NServiceBus" Version="8.0.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This should use a wildcard like the other csproj files to ensure the test run against the latest verion