### PR TITLE
Adjust wildcard

### DIFF
--- a/src/NServiceBus9.1/NServiceBus9.1.csproj
+++ b/src/NServiceBus9.1/NServiceBus9.1.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.1.*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="4.*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="4.0.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NServiceBus 9.1 project needs to be locked to NServiceBus.Newtonsoft.Json 4.0.x.