### PR TITLE
Work around .NET 10 RC1 SDK package pruning bug

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Workaround to fix problem with RC1 SDK not turning on package pruning when project is multi-targeted">

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -4,4 +4,9 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Label="Workaround to fix problem with RC1 SDK not turning on package pruning when project is multi-targeted">
+    <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
+    <RestoreEnablePackagePruning Condition="'$(TargetFramework)' == 'net472'">false</RestoreEnablePackagePruning>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
It looks like package pruning isn't working for multi-targeted projects with the .NET 10 RC1 SDK, so this works around the bug by forcing it on.

I've also gone ahead and set the LangVersion to `14.0` since that's now possible.