### PR TITLE
Prepare for NServiceBus 10 - Remove LangVersion

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,9 +1,5 @@
 ﻿<Project>
 
-  <PropertyGroup>
-    
-  </PropertyGroup>
-
   <PropertyGroup Label="Workaround to fix problem with RC1 SDK not turning on package pruning when project is multi-targeted">
     <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
     <RestoreEnablePackagePruning Condition="'$(TargetFramework)' == 'net472'">false</RestoreEnablePackagePruning>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
 
   <PropertyGroup>
-    <LangVersion>14.0</LangVersion>
+    
   </PropertyGroup>
 
   <PropertyGroup Label="Workaround to fix problem with RC1 SDK not turning on package pruning when project is multi-targeted">


### PR DESCRIPTION
Now that .NET 10 RC1 has been released, we don't need to set the language anymore.