### PR TITLE
Suppress vulnerability warning for log4net 1.2.10

### DIFF
--- a/src/NServiceBus3.3/NServiceBus3.3.csproj
+++ b/src/NServiceBus3.3/NServiceBus3.3.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2cwj-8chv-9pp9" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-4f7c-pmjv-c25w" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It is not possible to upgrade to v3.3 of log4net for the NServiceBus 3.3 project.