### PR TITLE
Pin Newtonsoft.Json package version to 5.0.0 for NServiceBus 10.0

### DIFF
--- a/src/NServiceBus10.0/NServiceBus10.0.csproj
+++ b/src/NServiceBus10.0/NServiceBus10.0.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="10.0.*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="5.*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change locks the version of https://github.com/Particular/NServiceBus.Newtonsoft.Json/ to 5.0.0 for NSB 10.0.0, which allow us to release https://github.com/Particular/NServiceBus.Newtonsoft.Json/releases/tag/5.0.1 which requires NSB 10.1.4.