### PR TITLE
update System.Security.Cryptography.Xml to  Version="8.0.4"

### DIFF
--- a/src/NServiceBus9.0/NServiceBus9.0.csproj
+++ b/src/NServiceBus9.0/NServiceBus9.0.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.0.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="4.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus9.1/NServiceBus9.1.csproj
+++ b/src/NServiceBus9.1/NServiceBus9.1.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="9.1.*" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="4.0.*" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR addresses the following

- https://github.com/particular/NServiceBus.Serializers.CompatTests/issues/383 - System.Security.Cryptography.Xml
- https://github.com/particular/NServiceBus.Serializers.CompatTests/issues/382 - System.Security.Cryptography.Xml
- https://github.com/particular/NServiceBus.Serializers.CompatTests/issues/378 -
- https://github.com/particular/NServiceBus.Serializers.CompatTests/issues/381 -System.Security.Cryptography.Xml